### PR TITLE
Updates to webpack logging output and working directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ var symlinkOrCopySync = require('symlink-or-copy').sync;
 
 var PreventResolveSymlinkPlugin = require('./prevent-resolve-symlink-plugin');
 
-
 function WebpackFilter(inputNode, options) {
   if (!(this instanceof WebpackFilter)) return new WebpackFilter(inputNode, options);
 
@@ -32,6 +31,8 @@ WebpackFilter.prototype.initializeCompiler = function() {
   if (this.options.cache) throw new Error("WebpackFilter will set the webpack cache, you shouldn't set it.");
   if (this.options.output && this.options.output.path) throw new Error("WebpackFilter will set the webpack output.path, you shouldn't set it.");
 
+  var resp, cwd;
+
   // Input tree path from broccoli
   this.options.context = this.inputPaths[0];
 
@@ -50,12 +51,17 @@ WebpackFilter.prototype.initializeCompiler = function() {
 
   this.options.resolve.root.push(this.inputPaths[0]);
 
+  // Change our working directory so resolve.modulesDirectories searches the
+  // latest broccoli piped version of our project rather than the original copies on disk.
+  cwd = process.cwd();
+  process.chdir(this.inputPaths[0]);
+
   // Let webpack do all the caching (we will call webpack's compile method every
   // build and rely on it to only build what is necessary)
   this.options.cache = this._webpackCache = {};
 
   // By default, log webpack's output to the console
-  this.options.logStats = this.options.logStats || true;
+  this.options.logStats = (this.options.logStats === undefined) ? true : this.options.logStats;
 
   // Prevent Webpack's ResultSymlinkPlugin from breaking relative paths in symlinked
   // modules (a common problem with Broccoli's highly symlinked output trees).
@@ -67,7 +73,12 @@ WebpackFilter.prototype.initializeCompiler = function() {
     );
   }
 
-  return webpack(this.options);
+  // Run webpack
+  resp = webpack(this.options);
+
+  // Switch back to original working directory
+  process.chdir(cwd);
+  return resp;
 }
 
 WebpackFilter.prototype.build = function() {
@@ -79,39 +90,31 @@ WebpackFilter.prototype.build = function() {
 
   return new RSVP.Promise(function(resolve, reject) {
     that.compiler.run(function(err, stats) {
-      var jsonStats = stats.toJson();
 
-      if (that.options.logStats) {
-        var loggingOptions;
-
-        // Allow options.logStats to be a string or object that is passed to
-        // stats.toString(). More info in:
-        //   - http://webpack.github.io/docs/node.js-api.html#stats-tostring
-        //   - https://github.com/webpack/webpack/pull/1323
-        if (that.options.logStats === true) {
-          loggingOptions = 'verbose';
-        } else {
-          loggingOptions = that.options.logStats;
-        }
-
-        console.log("\n[webpack]", stats.toString(loggingOptions));
+      // If there is a Webpack error, show it and reject
+      if(err){
+        console.error('Error in', err.module.rawRequest);
+        console.log(err.message);
+        console.log(err.details);
+        reject(err);
       }
 
+      // If we finished, show the logging we want to see
+      var jsonStats = stats.toJson();
+      if (that.options.logStats) console.log("\n[webpack]", stats.toString(that.options.logStats));
       if (jsonStats.errors.length > 0) jsonStats.errors.forEach(console.error);
       if (jsonStats.warnings.length > 0) jsonStats.warnings.forEach(console.warn);
-      if (err || jsonStats.errors.length > 0) {
-        reject(err);
-      } else {
-        // Get all of the assets from webpack, both emitted in this current compile
-        // pass and not emitted (aka, cached). And then symlink all of them from the
-        // cache folder (where webpack writes) to the output folder
-        jsonStats.assets.map(function(asset) {
-          mkdirp.sync(path.dirname(that.outputPath + '/' + asset.name));
-          symlinkOrCopySync(that.cachePath + '/' + asset.name, that.outputPath + '/' + asset.name);
-        });
 
-        resolve();
-      }
+      // Get all of the assets from webpack, both emitted in this current compile
+      // pass and not emitted (aka, cached). And then symlink all of them from the
+      // cache folder (where webpack writes) to the output folder
+      jsonStats.assets.map(function(asset) {
+        mkdirp.sync(path.dirname(that.outputPath + '/' + asset.name));
+        symlinkOrCopySync(that.cachePath + '/' + asset.name, that.outputPath + '/' + asset.name);
+      });
+
+      resolve();
+
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-webpack-cached",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Yet another webpack plugin for Broccoli. This one relies on webpack's caching for speed, but does it in a way that works well as a broccoli plugin (symlinking from the webpack cache to the output folder as needed).",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
- If an error is thrown, catch it before trying to output logging info (currently it fails hard because stats is undefined when it tries to call `.toJson()`)
- Update consumption of logStats to actually get passed to stats.toString
  - Currently always defaults to verbose with no way to override
  - Instead, default to normal log level and proxy through what is passed if logStats exists.
- While webpack is running, change working directory to broccoli input tree. Switch back on exit.
  - Currently, if you add a resolve.modulesDirectories option, it starts its search in the original project location
